### PR TITLE
feat: optimize and massage output

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,7 +37,7 @@ const generateFileConfig = (setName, subSystemName) => {
       );
     },
     options: {
-      selector: `.spectrum--${selector}`,
+      selector: `.spectrum--${subSystemName}.spectrum--${selector}`,
       showFileHeader: false,
       outputReferences: true,
       sets
@@ -59,7 +59,7 @@ const generateGlobalConfig = (subSystemName) => {
       );
     },
     options: {
-      selector: `.spectrum`,
+      selector: `.spectrum--${subSystemName}`,
       showFileHeader: false,
       outputReferences: true,
       sets

--- a/config.js
+++ b/config.js
@@ -25,6 +25,7 @@ const generateFileConfig = (subSystemName, setName) => {
       );
     },
     options: {
+      selector: `.spectrum--${setName}`,
       showFileHeader: false,
       outputReferences: true,
       sets

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "@adobe/spectrum-tokens": "^12.0.0-beta.17",
     "style-dictionary": "^3.7.0",
-    "style-dictionary-sets": "^1.3.3"
+    "style-dictionary-sets": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "@adobe/spectrum-tokens": "^12.0.0-beta.17",
     "style-dictionary": "^3.7.0",
-    "style-dictionary-sets": "^1.4.0"
+    "style-dictionary-sets": "^1.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,10 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-style-dictionary-sets@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-1.3.3.tgz#1d93c3e0efc784f963a964fda35cfe575e3ae3af"
-  integrity sha512-HnxeOfTmfsPcE9TFkKTTpaR3M5MKy0KrMnXOfbx1Ywek9ty9RAnley/c2cvxZU6VUBqyMPne80B6ln9PpJ01ww==
+style-dictionary-sets@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-1.4.0.tgz#5a25a280f69d37e75e9d798496f99024df39195f"
+  integrity sha512-SPAI1EWqyfzqITGBfTUuAFjL8itAeqRLu3XFQbtgZfUbNgCm7e5ya3WPiDue9L2Tf7/hb0779CHq6kDq1yNP8Q==
   dependencies:
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,10 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-style-dictionary-sets@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-1.4.0.tgz#5a25a280f69d37e75e9d798496f99024df39195f"
-  integrity sha512-SPAI1EWqyfzqITGBfTUuAFjL8itAeqRLu3XFQbtgZfUbNgCm7e5ya3WPiDue9L2Tf7/hb0779CHq6kDq1yNP8Q==
+style-dictionary-sets@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/style-dictionary-sets/-/style-dictionary-sets-1.4.1.tgz#d8c50179879b706e8b84d7707e4b0206acd27d4f"
+  integrity sha512-9t3E2YEE7kftvVAAnTP1MDQfBj6s2gU7Ox8mEsiQzXXkIOSm1qssthpMWjZ1Gv3cWSzyrAsBiiwnVgt6dM7OxA==
   dependencies:
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
## Description

This PR changes the way output is generated so files only contain what changes.

basically, we have top-level `light`/`dark`/`darkest` as well as `globals`/`medium`/`large` now, and the files in `express/` and `spectrum/` only contain the changes that happen due to those systems (very few, actually…).

* everything in `/global-vars.css` simply never changes — not according to systems, scales, or color stops. 
* everything in `/light|darkest|dark-vars.css` changes according to color stop, but not according to system or scale.
* everything in `/medium|large.css` changes according to scale, but not according to system or color stop.

and of course, everything in `/express` and `/spectrum` in the respective files changes according to system + whatever the filename says. *curiously,* there are no tokens that change according to system AND colorstop, hence why there are no `spectrum|express/light|darkest|dark-vars.css` at all!

i think this approach will give us the slimmest possible output and will make it simple to switch between systems with very little overhead. it is a departure from the current way we ship these variables, but i think it’s for the better — we no longer need a separate release for each system, the overhead of including both systems in the tokens is only 2,166 bytes.

![image](https://user-images.githubusercontent.com/201344/164570273-61719a3b-ca2c-450c-aba6-3ef10b98b563.png)

## Implications

This work plays into the discussion we had earlier around keeping system overrides inside of component CSS. After this, you can load every one of these files together and they'll all co-exist, no conflicts at all. Then, you can apply `.spectrum--express` or `.spectrum--spectrum` (lol) to switch between design systems.

This enables us to have system overrides directly within components (!)

If this is undesirable, a simple change can remove the `.spectrum--express` and `.spectrum--spectrum` selectors from the `/express`/`/spectrum` folders, and the files can be use as normal.

## Note

This PR depends on https://github.com/GarthDB/style-dictionary-sets/pull/30 and will have to be updated when that is merged and released.